### PR TITLE
Fix big messages, write failures, and delays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "quad-net"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Fedor Logachev <not.fl3@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
+homepage = "https://github.com/not-fl3/quad-net"
+repository = "https://github.com/not-fl3/quad-net"
 description = "Miniquad friendly network abstractions"
 
 [features]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -36,7 +36,7 @@ async fn main() {
 
         if is_mouse_button_down(MouseButton::Left) {
             let (x, y) = mouse_position();
-            socket.send_bin(&(x, y));
+            socket.send_bin(&(x, y)).unwrap();
         }
         next_frame().await
     }

--- a/js/quad-net.js
+++ b/js/quad-net.js
@@ -11,7 +11,7 @@ register_plugin = function (importObject) {
     importObject.env.http_try_recv = http_try_recv;
 }
 
-miniquad_add_plugin({ register_plugin, on_init, version: "0.1.1", name: "quad_net" });
+miniquad_add_plugin({ register_plugin, on_init, version: "0.2.0", name: "quad_net" });
 
 var quad_socket;
 var connected = 0;

--- a/src/quad_socket/client.rs
+++ b/src/quad_socket/client.rs
@@ -15,16 +15,18 @@ pub struct QuadSocket {
 }
 
 impl QuadSocket {
-    pub fn send(&mut self, data: &[u8]) {
+    pub fn send(&mut self, data: &[u8]) -> Result<(), Error> {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            self.tcp_socket.send(data);
+            self.tcp_socket.send(data)?;
         }
 
         #[cfg(target_arch = "wasm32")]
         {
             self.web_socket.send_bytes(data);
         }
+
+        Ok(())
     }
 
     pub fn try_recv(&mut self) -> Option<Vec<u8>> {
@@ -42,10 +44,10 @@ impl QuadSocket {
 
 #[cfg(feature = "nanoserde")]
 impl QuadSocket {
-    pub fn send_bin<T: nanoserde::SerBin>(&mut self, data: &T) {
+    pub fn send_bin<T: nanoserde::SerBin>(&mut self, data: &T) -> Result<(), Error>  {
         use nanoserde::SerBin;
 
-        self.send(&SerBin::serialize_bin(data));
+        self.send(&SerBin::serialize_bin(data))
     }
 
     pub fn try_recv_bin<T: nanoserde::DeBin + std::fmt::Debug>(&mut self) -> Option<T> {

--- a/src/quad_socket/protocol.rs
+++ b/src/quad_socket/protocol.rs
@@ -1,37 +1,50 @@
 use std::io::ErrorKind;
 
 #[derive(Debug)]
-pub enum MessageReader {
-    Empty,
-    Amount(usize),
+pub(crate) struct MessageReader {
+    buffer: Vec<u8>,
 }
 
 impl MessageReader {
     pub fn new() -> MessageReader {
-        MessageReader::Empty
+        MessageReader {
+            buffer: Vec::new()
+        }
     }
 
     pub fn next(&mut self, mut stream: impl std::io::Read) -> Result<Option<Vec<u8>>, ()> {
-        let mut bytes = [0 as u8; 255];
+        let mut bytes = [0; 16 * 1024];
 
-        match self {
-            MessageReader::Empty => match stream.read_exact(&mut bytes[0..1]) {
-                Ok(_) => {
-                    *self = MessageReader::Amount(bytes[0] as usize);
-                    Ok(None)
-                }
-                Err(err) if err.kind() == ErrorKind::WouldBlock => Ok(None),
-                Err(_err) => Err(()),
-            },
-            MessageReader::Amount(len) => match stream.read_exact(&mut bytes[0..*len]) {
-                Ok(_) => {
-                    let msg = bytes[0..*len].to_vec();
-                    *self = MessageReader::Empty;
-                    Ok(Some(msg))
-                }
-                Err(err) if err.kind() == ErrorKind::WouldBlock => Ok(None),
-                Err(_) => Err(()),
-            },
+        let bytes_read = match stream.read(&mut bytes) {
+            Ok(bytes_read) => bytes_read,
+            Err(err) if err.kind() == ErrorKind::WouldBlock => return Ok(None),
+            Err(_err) => return Err(()),
+        };
+
+        if bytes_read == 0 {
+            // Disconnected
+            return Err(());
         }
+
+        // Read the first 4 bytes, which encode the message's length
+        self.buffer.extend_from_slice(&bytes[..bytes_read]);
+
+        if self.buffer.len() < 4 {
+            return Ok(None);
+        }
+
+        use std::convert::TryInto;
+        let four_bytes: [u8; 4] = self.buffer[0..4].try_into().unwrap();
+        let message_size = u32::from_be_bytes(four_bytes) as usize;
+
+        // Keep receiving until the whole message is here
+        if self.buffer.len() < 4 + message_size {
+            return Ok(None);
+        }
+
+        let message = self.buffer[4..4+message_size].to_vec();
+        self.buffer.drain(..4+message_size);
+
+        Ok(Some(message))
     }
 }


### PR DESCRIPTION
Fixed a few things:
* Messages larger than 256 bytes were being corrupted by the u8 message length
* Writes were being delayed because of blocking and incomplete writes (my client was lagging behind compared to the server)
* Reads were potentially discarding bytes (behavior on WouldBlock for `read_exact` is unspecified)
* Sprinkled some yield_now()'s in a few places to be nicer

Bumped version because `send` and `send_bin`'s signatures became incompatible, although most people just need to add an `.unwrap()` on them.

Ideally this would use fully-blocking calls everywhere, although that for some reason results in massive delays on messages (I'm guessing it interferes with mpsc message passing or something? not sure yet). I might try to rewrite it to block, the code will be simpler.