### PR TITLE
Permit close websockets

### DIFF
--- a/src/web_socket.rs
+++ b/src/web_socket.rs
@@ -147,6 +147,12 @@ mod pc_web_socket {
                 .send(ws::Message::Binary(data.to_vec()))
                 .unwrap();
         }
+
+        pub fn close(&self) -> Result<(), String> {
+            self.sender
+                .close(qws::CloseCode::Normal)
+                .or_else(|error| return Err(error.to_string()))
+        }
     }
 }
 


### PR DESCRIPTION
Hello,

I'm confronting a bug when I recreate web sockets. There is the situation in my program : 

1. [Websocket::connect](https://github.com/not-fl3/quad-net/blob/207da3a4b439ec45d878bde3995af8285940ae20/src/web_socket.rs#L105) is called one time to establish the connection.
2. In a second time, websocket is destroyed (game display another screen where web socket is unnecessary)
3. In a third time, the step 1 code is called again, so [Websocket::connect](https://github.com/not-fl3/quad-net/blob/207da3a4b439ec45d878bde3995af8285940ae20/src/web_socket.rs#L105) called again.

It results an error when messages received by first websocket: first created websocket has never been closed. So in my game, I use the following `close` function to prevent this.

**But** I have a similar issue with webassembly target. Error in exact previous situation. Brower errors are : 

```
Uncaught DOMException: An attempt was made to use an object that is not, or is no longer, usable not-fl3.github.io__miniquad-samples__mq_js_bundle.js:1

PanicInfo { payload: Any { .. }, message: Some(already borrowed: BorrowMutError), location: Location { file: "/home/bastiensevajol/.cargo/registry/src/github.com-1ecc6299db9ec823/miniquad-0.3.10/src/native/wasm.rs", line: 95, col: 35 }, can_unwind: true } not-fl3.github.io__miniquad-samples__mq_js_bundle.js:1:10657

Uncaught RuntimeError: unreachable executed
    onmousemove http://127.0.0.1:5000/static/not-fl3.github.io__miniquad-samples__mq_js_bundle.js:1
engine.wasm:1948550:1

PanicInfo { payload: Any { .. }, message: Some(already borrowed: BorrowMutError), location: Location { file: "/home/bastiensevajol/.cargo/registry/src/github.com-1ecc6299db9ec823/miniquad-0.3.10/src/native/wasm.rs", line: 95, col: 35 }, can_unwind: true } not-fl3.github.io__miniquad-samples__mq_js_bundle.js:1:10657
```

The `src/native/wasm.rs` concerned code is : 

```rust
fn with<T, F: FnOnce(&mut WasmGlobals) -> T>(f: F) -> T {
    GLOBALS.with(|globals| {
        let mut globals = globals.borrow_mut();
        let globals = globals.as_mut().unwrap();
        f(globals)
    })
}
```

Can you help me about solving this bug with webassembly too ? I am noob with WASM/JS things :(