### PR TITLE
fix quad-net

### DIFF
--- a/src/web_socket.rs
+++ b/src/web_socket.rs
@@ -36,7 +36,7 @@ pub(crate) mod js_web_socket {
                     data.field("data").to_string(&mut s);
                     buf = s.into_bytes();
                 } else {
-                    data.field("data").to_byte_buffer(&mut buf);
+                    data.to_byte_buffer(&mut buf);
                 }
                 return Some(buf);
             }


### PR DESCRIPTION
The client/server examples currently do not work when client.rs is compiled to wasm.
I tracked down the issue and it's because `data.field("data")` points to an undefined js_objects source while `data` itself is the correct JS_object to get the ws message from.

I needed to make this fix to use the `try_recv_bin` method in WASM.