### PR TITLE
Fix broken example, make gws SSL feature optional for Win32 builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,13 @@ description = "Miniquad friendly network abstractions"
 
 [features]
 default = ["nanoserde"]
+ssl = ["qws/ssl"]  # Optional: getting/building OpenSSL on Win32 is difficult
 
 [dependencies]
 nanoserde = { version = "0.1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-qws = { version = "0.7.9", features = ["ssl"] }
+qws = { version = "0.7.9", default-features = false }
 ureq = "2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,9 +5,9 @@ use quad_net::quad_socket::client::QuadSocket;
 #[macroquad::main("Networking!")]
 async fn main() {
     #[cfg(not(target_arch = "wasm32"))]
-    let mut socket = QuadSocket::connect("0.0.0.0:8090").unwrap();
+    let mut socket = QuadSocket::connect("localhost:8090").unwrap();
     #[cfg(target_arch = "wasm32")]
-    let mut socket = QuadSocket::connect("ws://0.0.0.0:8091").unwrap();
+    let mut socket = QuadSocket::connect("ws://localhost:8091").unwrap();
 
     #[cfg(target_arch = "wasm32")]
     {


### PR DESCRIPTION
The client example wasn't working because it was trying to connect to `0.0.0.0` which only makes sense for the server to serve on.

Made the qws SSL feature optional because I could not get OpenSSL built on Windows and this fixed it for me. It seems like the SSL feature wasn't being used by quad-net as well.

Ultimately, I wasn't able to get quad-net to work for me but I didn't want to lose my efforts to hack it.

I'd love for quad-net to receive some love so that I can make Macroquad WASM games that are capable of 2-3 person multiplayer in the browser. Looked at Quad-Net, Naia, Websocket-Client, Matchbox, and SpacetimeDB, but none of them worked for me due to Macroquads unique build process. There's a manual workaround to use wasm-bindgen libraries with Macroquad but ultimately I think for scaling Macroquad for more users the build system needs to be overhauled to use industry-standard Rust tools like wasm-bindgen, etc.